### PR TITLE
#7 - implement drupal-libraries-include

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -216,12 +216,11 @@ class Plugin implements PluginInterface, Capable, EventSubscriberInterface {
   protected function processPackage(array $processed_drupal_libraries, array $drupal_libraries, PackageInterface $package) {
     $extra = $package->getExtra();
 
-    if (empty($extra['drupal-libraries']) || !is_array($extra['drupal-libraries'])) {
-      return $processed_drupal_libraries;
-    }
-
     if ($package->getType() === 'project') {
-      foreach ($extra['drupal-libraries-include'] ?? [] as $include) {
+      foreach (['drupal-libraries', 'drupal-libraries-include'] as $key) {
+        $extra[$key] = is_array($extra[$key] ?? NULL) ? $extra[$key] : [];
+      }
+      foreach ($extra['drupal-libraries-include'] as $include) {
         if (!preg_match('/composer.libraries.json$/', $include) || !file_exists($include)) {
           continue;
         }
@@ -237,6 +236,10 @@ class Plugin implements PluginInterface, Capable, EventSubscriberInterface {
           }
         }
       }
+    }
+
+    if (empty($extra['drupal-libraries']) || !is_array($extra['drupal-libraries'])) {
+      return $processed_drupal_libraries;
     }
 
     // Install each library.


### PR DESCRIPTION
As suggested in the issue. 

1) Add [this](https://git.drupalcode.org/project/webform/-/blob/6.1.4/composer.libraries.json) to the extra section of your main composer.json:

```
        "drupal-libraries-include": [
            "web/modules/contrib/webform/composer.libraries.json"
        ],
```

Perform a `composer install` => Packages should be in your libraries Folder

2) Remove it again from your main composer.json

Perform a `composer install` => Packages should be gone

3) Some kind of test would be nice, but I couldn't get it to run with phpunit.
